### PR TITLE
add failing test for react/jsx-one-expression-per-line

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -40,3 +40,19 @@ test('no errors', t => {
 	const errors = runEslint('var React = require(\'react\');\nvar el = <div/>;', conf);
 	t.deepEqual(errors, []);
 });
+
+// react/jsx-one-expression-per-line
+const oneExpression = `
+var React = require('react');
+var el = (
+	<div>
+		hello
+	</div>
+);
+`
+test.failing("doesn't complain incorrectly about newlines", t => {
+	const conf = require('..');
+
+	const errors = runEslint(oneExpression, conf);
+	t.deepEqual(errors, []);
+})


### PR DESCRIPTION
Hopefully I've understood the rule correctly.