### PR TITLE
`allowAllCaps` for react components

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,12 @@ module.exports = {
 			'error',
 			'syntax'
 		],
-		'react/jsx-pascal-case': 'error',
+		'react/jsx-pascal-case': [
+			'error',
+			{
+				allowAllCaps: true,
+			}
+		],
 		'react/jsx-sort-props': [
 			'error',
 			{


### PR DESCRIPTION
Change to [`react/jsx-sort-props` rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) to allow react components that are allcaps

Allows components like [`<TR />` and `<TD />`](https://github.com/revivek/oy)