### PR TITLE
Add `react/jsx-first-prop-new-line` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ module.exports = {
 			'error',
 			'never'
 		],
+		'react/jsx-first-prop-new-line': 'error',
 		'react/jsx-indent': [
 			'error',
 			'tab',


### PR DESCRIPTION
This is currently allowed:

```jsx
<tag attr1
	attr2
/>
```

With this rule, it will be fixed to:


```jsx
<tag
	attr1
	attr2
/>
```

or you can use:


```jsx
<tag attr1 attr2/>
```

More info on https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md

The default `multiline-multiprop` makes the most sense to me because it disallows

```jsx
<tag
	onlyOneAttr
/>
```