### PR TITLE
Allow react-intl’s usage of style prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,12 +72,15 @@ module.exports = {
 			'never'
 		],
 		'react/static-property-placement': 'error',
-		'react/style-prop-object': ['error', {
-			allow: [
-				// This allows react-intl’s <FormattedNumber value={0.42} style='percent' />
-				'FormattedNumber'
-			]
-		}],
+		'react/style-prop-object': [
+			'error',
+			{
+				allow: [
+					// This allows react-intl’s `<FormattedNumber value={0.42} style='percent'/>`.
+					'FormattedNumber'
+				]
+			}
+		],
 		'react/void-dom-elements-no-children': 'error',
 		'react/jsx-boolean-value': 'error',
 		'react/jsx-closing-bracket-location': [

--- a/index.js
+++ b/index.js
@@ -72,7 +72,12 @@ module.exports = {
 			'never'
 		],
 		'react/static-property-placement': 'error',
-		'react/style-prop-object': 'error',
+		'react/style-prop-object': ['error', {
+			allow: [
+				// This allows react-intl’s <FormattedNumber value={0.42} style='percent' />
+				'FormattedNumber'
+			]
+		}],
 		'react/void-dom-elements-no-children': 'error',
 		'react/jsx-boolean-value': 'error',
 		'react/jsx-closing-bracket-location': [


### PR DESCRIPTION
Update `react/style-prop-object` rule to allow react-intl’s usage of the `style` prop in the [`FormattedNumber` component](https://formatjs.io/docs/react-intl/components/#formattednumber), which is to be used as such:

```jsx
<FormattedNumber value={0.42} style='percent' />
```

---

I originally implemented this in [eslint-config-xo-nextjs](https://github.com/tusbar/eslint-config-xo-nextjs), which extends this configuration, but I believe it’s more suitable here.

Also, this repository doesn’t have any test or linter, I have added some [tests](https://github.com/tusbar/eslint-config-xo-nextjs/blob/master/__tests__/react.js#L43-L57) in the aforementioned repository that lints [some](https://github.com/tusbar/eslint-config-xo-nextjs/blob/master/__tests__/__fixtures__/react/style-prop-object.correct.js) [fixtures](https://github.com/tusbar/eslint-config-xo-nextjs/blob/master/__tests__/__fixtures__/react/style-prop-object.incorrect.js) using xo’s [`lintFile`](https://github.com/tusbar/eslint-config-xo-nextjs/blob/master/lib/lint-fixture.js).

Maybe something similar could be implemented in this repo.